### PR TITLE
Add cleanup function on willDestroyElement

### DIFF
--- a/addon/components/tinymce-editor.js
+++ b/addon/components/tinymce-editor.js
@@ -43,5 +43,14 @@ export default Ember.Component.extend({
     }
 
     tinymce.init(Ember.$.extend( customOptions, options ));
-  }))
+  })),
+
+  // Destroy tinymce editor instance when editor is removed from the page.  Otherwise, it won't be
+  // created again when added back to the page (i.e. navigating away from and back to the route).
+  cleanUp: on('willDestroyElement', function() {
+    let editor = this.get('editor');
+    if (editor) {
+      editor.destroy();
+    }
+  })
 });


### PR DESCRIPTION
Destroys tinymce editor instance on willDestroyElement so that it can be successfully recreated if/when the element is recreated - for example, navigating away from and back to the route which the
editor is part of.

If you don't destroy the editor instance, TinyMCE initialises correctly the first time, but if you navigate to another route and back again, you just get a plain textarea - TinyMCE seems to skip initialising it because it still has a reference to the editor it initialised for the field the first time it was added to the page.