### PR TITLE
Small tweaks to the component

### DIFF
--- a/addon/components/tinymce-editor.js
+++ b/addon/components/tinymce-editor.js
@@ -35,7 +35,8 @@ export default Ember.Component.extend({
       return;
     }
     
-    editor.on('change keyup keydown keypress mousedown', run.bind(this, this.debounceContentChanged));
+    editor.on('change keyup keydown keypress mousedown',
+              run.bind(this, this.debounceContentChanged, editor, changeDebounce));
   }),
 
   initTiny: on('didInsertElement', observer('options', function() {

--- a/addon/components/tinymce-editor.js
+++ b/addon/components/tinymce-editor.js
@@ -66,7 +66,6 @@ export default Ember.Component.extend({
     if (editor) {
       editor.off('change keyup keydown keypress mousedown');
       editor.destroy();
-      this.set('editor', null);
     }
   })
 });

--- a/addon/components/tinymce-editor.js
+++ b/addon/components/tinymce-editor.js
@@ -2,14 +2,15 @@ import Ember from 'ember';
 const {observer, on, run} = Ember;
 
 export default Ember.Component.extend({
-  editor: undefined,
+  editor: null,
   tagName: 'textarea',
   _contentChangedListener: null,
+  changeDebounce: 10,
 
   valueChanged: observer('value', function() {
-    let editor = this.get('editor');
-    if (editor && editor.getContent() !== this.get('value')) {
-      editor.setContent(this.get('value') || '');
+    let {editor, value} = this.getProperties('editor', 'value');
+    if (editor && editor.getContent() !== value) {
+      editor.setContent(value || '');
     }
   }),
 
@@ -18,29 +19,36 @@ export default Ember.Component.extend({
   },
 
   contentChanged(editor) {
-    if (!editor.isNotDirty)
+    if (!editor.isNotDirty) {
       this.onValueChanged(editor.getContent());
+    }
   },
-
+  
+  debounceContentChanged(editor, time){
+    run.debounce(this, this.contentChanged, editor, time);
+  },
+  
   setEvents: observer('editor', function() {
-    let editor = this.get('editor');
-
-    this._contentChangedListener = run.bind(this, ()=> {
-      run.debounce(this, this.contentChanged, editor, 1);
-    });
-
-    editor.on('change keyup keydown keypress mousedown', this._contentChangedListener);
+    let {changeDebounce, editor} = this.getProperties('changeDebounce', 'editor');
+    
+    if (!editor){
+      return;
+    }
+    
+    editor.on('change keyup keydown keypress mousedown', run.bind(this, this.debounceContentChanged));
   }),
 
   initTiny: on('didInsertElement', observer('options', function() {
     let {options, editor} = this.getProperties('options', 'editor');
+    
+    let initFunction = (editor) => {
+      this.set('editor', editor);
+      this.get('editor').setContent(this.get('value') || ''); //Set content with default text
+    }
 
     let customOptions = {
       selector: `#${this.get('elementId')}`,
-      init_instance_callback: (editor) => {
-        this.set('editor', editor);
-        this.get('editor').setContent(this.get('value') || ''); //Set content with default text
-      },
+      init_instance_callback: run.bind(this, initFunction)
     };
 
     if (editor){
@@ -49,15 +57,16 @@ export default Ember.Component.extend({
     }
     
     run.later( () => {
-      tinymce.init(Ember.$.extend( customOptions, options ));
+      tinymce.init(Ember.assign({}, options, customOptions));
     }, 10)      
   })),
 
   cleanUp: on('willDestroyElement', function() {
     let editor = this.get('editor');
     if (editor) {
-      editor.off('change keyup keydown keypress mousedown', this._contentChangedListener);
+      editor.off('change keyup keydown keypress mousedown');
       editor.destroy();
+      this.set('editor', null);
     }
   })
 });


### PR DESCRIPTION
Hey, I've just made a few tweaks to the code:

1. Use `Ember.assign` instead of `Ember.$.extend`

2. Use `null` as the default `editor` value instead of `undefined`

3. Allow customizing the `changeDebounce` time, and default it to 10 (1 is a bit too low I think?

4. Make the editor init function (tinymce `init_instance_callback`) run in the run loop by using `Ember.run.bind`

5. Moved the changeDebounce function out to a class function, and bind it with `run.bind`.

Please let me know what you think, I can add/remove any of the points above as needed.