### PR TITLE
Set dirty state to false when the value is changed

### DIFF
--- a/addon/components/tinymce-editor.js
+++ b/addon/components/tinymce-editor.js
@@ -21,6 +21,7 @@ export default Ember.Component.extend({
   contentChanged(editor) {
     if (!editor.isNotDirty) {
       this.onValueChanged(editor.getContent());
+      editor.setDirty(false);
     }
   },
   

--- a/addon/components/tinymce-editor.js
+++ b/addon/components/tinymce-editor.js
@@ -19,7 +19,8 @@ export default Ember.Component.extend({
   },
 
   contentChanged(editor) {
-    if (!editor.isNotDirty) {
+    let content = editor.getContent();
+    if (!editor.isNotDirty && content != this.get('value')) {
       this.onValueChanged(editor.getContent());
       editor.setDirty(false);
     }


### PR DESCRIPTION
`isNotDirty` will always repeatedly be true until `editor.save()` or `editor.setDirty(false)` is called. We should set it here, I use `setDirty` as `save` sounds like it could trigger unwanted side effects.