### PR TITLE
Added ability to configure for self hosted implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,19 @@ ENV:{
 
 Be aware _ver_ is a semver reflection of the Tinymce CDN which can introduce issues if a bad release is automatically picked up by your application
 
+You can load TinyMCE from a self hosted source:
+
+```js
+ENV:{
+  ...,
+  tinyMCE:{
+    srcScript: 'https://self_hosted_server_path'
+  }
+}
+```
+
+Remember if your self hosted resource resides in a different domain than your application, ensure you configure CORS otherwise aspects of the editor such as fonts, styles, skins, etc. may fail to load due to cross site scripting safety measures. 
+
 Set this to `false` to disable including automatically:
 
 ```js

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ You can load TinyMCE from a self hosted source:
 ENV:{
   ...,
   tinyMCE:{
-    srcScript: 'https://self_hosted_server_path'
+    scriptSrc: 'https://path/to/locally-hosted/tinymce/js/tinymce.min.js'
   }
 }
 ```

--- a/index.js
+++ b/index.js
@@ -17,7 +17,13 @@ module.exports = {
     ) {
       const version = config['tinyMCE']['version'];
       const referrerpolicy = config['tinyMCE']['refererPolicy'] || 'origin';
+      const srcScript = config['tinyMCE']['srcScript'] || false;
       const src = `https://cdn.tiny.cloud/1/${apiKey}/tinymce/${version}/tinymce.min.js`;
+
+      if(srcScript){
+        src = config['tinyMCE']['scriptSrc'];
+      }
+
       return `<script type='text/javascript' src='${src}' crossorigin='${referrerpolicy}'></script>`;
     }
     return '';

--- a/index.js
+++ b/index.js
@@ -17,12 +17,7 @@ module.exports = {
     ) {
       const version = config['tinyMCE']['version'];
       const referrerpolicy = config['tinyMCE']['refererPolicy'] || 'origin';
-      const srcScript = config['tinyMCE']['srcScript'] || false;
-      const src = `https://cdn.tiny.cloud/1/${apiKey}/tinymce/${version}/tinymce.min.js`;
-
-      if(srcScript){
-        src = config['tinyMCE']['scriptSrc'];
-      }
+      const src = config['tinyMCE']['scriptSrc'] || `https://cdn.tiny.cloud/1/${apiKey}/tinymce/${version}/tinymce.min.js`;
 
       return `<script type='text/javascript' src='${src}' crossorigin='${referrerpolicy}'></script>`;
     }


### PR DESCRIPTION
In lieu of using the TinyCloud CDN and an API key, some might want to self host.  Adding this option allows a developer to specify a script source path documented by Tiny.  This is also a great alternative for those who want to use an earlier version or don't want to create a TinyCloud account and utilize an API key. 